### PR TITLE
Guard error of pysimm applying force field

### DIFF
--- a/psp/AmorphousBuilder.py
+++ b/psp/AmorphousBuilder.py
@@ -532,7 +532,17 @@ class Builder:
 
             f = forcefield.Gaff2()
             if atom_typing == 'pysimm':
-                s.apply_forcefield(f, charges='gasteiger')
+                try:
+                    print("Pysimm applying force field for {}.".format(mol2_file))
+                    s.apply_forcefield(f, charges='gasteiger')
+                except BaseException:
+                    print('Error applying force field with the mol2 file, switch to using cml file.')
+                    call('babel -ipdb {0}.pdb -ocml {0}.cml'.format(os.path.join(self.OutDir_xyz, output_prefix)), shell=True)
+                    s = system.read_cml('{}.cml'.format(os.path.join(self.OutDir_xyz, output_prefix)))
+                    for b in s.bonds:
+                        if b.a.bonds.count == 3 and b.b.bonds.count == 3:
+                            b.order = 4
+                    s.apply_forcefield(f, charges='gasteiger')
             elif atom_typing == 'antechamber':
                 MDlib.get_type_from_antechamber(s, mol2_file, 'gaff2', f, swap_dict)
                 s.pair_style = 'lj'

--- a/psp/MD_lib.py
+++ b/psp/MD_lib.py
@@ -847,7 +847,7 @@ def get_type_from_antechamber(s, mol2_file, types='gaff2', f=None, swap_dict=Non
         subprocess.call('{} -fi mol2 -i {} -fo ac -o {} -at {}'.format(ANTECHAMBER_EXEC, mol2_file, temp_ac_fname, types), shell=True)
         fr = open(temp_ac_fname, "r")
     except BaseException:
-        print('Error running Antechamber with the mol2 file, switch to using pdb file')
+        print('Error running Antechamber with the mol2 file, switch to using pdb file.')
         temp_pdb_fname = 'temp.pdb'
         s.write_pdb(temp_pdb_fname)
         subprocess.call('{} -fi pdb -i {} -fo ac -o {} -at {}'.format(ANTECHAMBER_EXEC, temp_pdb_fname, temp_ac_fname, types), shell=True)


### PR DESCRIPTION
Fix amor_gaff2 test bug: if using mol2 file for Pysimm atom typing leads to an error, switch to cml file format.