### PR TITLE
Enable LBCC charges for get_opls()

### DIFF
--- a/psp/AmorphousBuilder.py
+++ b/psp/AmorphousBuilder.py
@@ -319,6 +319,7 @@ class Builder:
                     resname=output_prefix,
                     charge=0,
                     opt=0,
+                    lbcc=True,
                     outdir='.',
                 )
                 os.rename(lig_output_fname, data_fname)


### PR DESCRIPTION
Make the `get_opls()` default charge method to LBCC